### PR TITLE
Improve the way to specify the path to texlab.jar.

### DIFF
--- a/README.org
+++ b/README.org
@@ -12,7 +12,11 @@
 #+BEGIN_SRC emacs-lisp -n
   (add-to-list 'load-path "path/to/lsp-latex")
   (require 'lsp-latex)
-  (setq lsp-latex-texlab-jar-file "path/to/texlab.jar")
+  ;; "texlab.jar" must be located at a directory contained in `exec-path'
+  (setq lsp-latex-texlab-jar-file 'search-from-exec-path)
+  ;; If you want to put "texlab.jar" somewhere else,
+  ;; you can specify the path to "texlab.jar" as follows:
+  ;; (setq lsp-latex-texlab-jar-file "/path/to/texlab.jar")
 
   (with-eval-after-load "tex-mode"
    (add-hook 'tex-mode-hook 'lsp)

--- a/README.org
+++ b/README.org
@@ -10,7 +10,7 @@
   - Now, you can use Language Server Protocol (LSP) on tex-mode or yatex-mode just to evaluate this:
 
 #+BEGIN_SRC emacs-lisp -n
-  (add-to-list 'load-path "path/to/lsp-latex")
+  (add-to-list 'load-path "/path/to/lsp-latex")
   (require 'lsp-latex)
   ;; "texlab.jar" must be located at a directory contained in `exec-path'
   (setq lsp-latex-texlab-jar-file 'search-from-exec-path)
@@ -22,7 +22,7 @@
    (add-hook 'tex-mode-hook 'lsp)
    (add-hook 'latex-mode-hook 'lsp))
 
-  ;; For YaYeX
+  ;; For YaTeX
   (with-eval-after-load "yatex"
    (add-hook 'yatex-mode-hook 'lsp))
 #+END_SRC

--- a/lsp-latex.el
+++ b/lsp-latex.el
@@ -45,11 +45,13 @@ This is used with `lsp-latex-java-argument-list'."
   :risky t
   :type '(repeat string))
 
-(defcustom lsp-latex-texlab-jar-file "texlab.jar"
+(defcustom lsp-latex-texlab-jar-file 'search-from-exec-path
   "File named \"texlab.jar\".
-You can install it from https://github.com/latex-lsp/texlab/releases/tag/v0.4.1 ."
+You can install it from https://github.com/latex-lsp/texlab/releases/tag/v0.4.1 .
+
+The value can be a string (path to \"texlab.jar\") or the symbol search-from-exec-path. See the docstring of `lsp-latex-get-texlab-jar-file'."
   :group 'lsp-latex
-  :type 'string)
+  :type '(choice string symbol))
 
 (defcustom lsp-latex-texlab-jar-argument-list '()
   "List of arguments passed to `lsp-latex-texlab-jar-file'. "
@@ -59,6 +61,28 @@ You can install it from https://github.com/latex-lsp/texlab/releases/tag/v0.4.1 
 
 
 
+(defun lsp-latex-get-texlab-jar-file ()
+  "Return the path to \"texlab.jar\".
+
+If `lsp-latex-texlab-jar-file' is a string, return it.
+If `lsp-latex-texlab-jar-file' is the symbol search-from-exec-path, then search a file named \"texlab.jar\" from `exec-path'."
+  (cond
+   ((stringp lsp-latex-texlab-jar-file)
+    lsp-latex-texlab-jar-file)
+   ((eq lsp-latex-texlab-jar-file 'search-from-exec-path)
+    (let* ((jar-filename "texlab.jar")
+           (jar-dir (or (seq-find (lambda (dir)
+                                    (let ((path (format "%s/%s"
+                                                        dir jar-filename)))
+                                      (when (file-exists-p path)
+                                        path)))
+                                  exec-path)
+                        (error (format "\"%s\" not found in `exec-path'"
+                                       jar-filename)))))
+      (format "%s/%s"
+              jar-dir jar-filename)))
+   (t (error "invalid value of `lsp-latex-texlab-jar-file'"))))
+
 (defun lsp-latex-new-connection ()
   ""
   (append
@@ -66,7 +90,7 @@ You can install it from https://github.com/latex-lsp/texlab/releases/tag/v0.4.1 
     lsp-latex-java-executable
     lsp-latex-java-argument-list)
    (cons
-    lsp-latex-texlab-jar-file
+    (lsp-latex-get-texlab-jar-file)
     lsp-latex-texlab-jar-argument-list)))
 
 ;; Copied from `lsp-clients--rust-window-progress' in `lsp-rust'.

--- a/lsp-latex.el
+++ b/lsp-latex.el
@@ -51,7 +51,7 @@ You can install it from https://github.com/latex-lsp/texlab/releases/tag/v0.4.1 
 
 The value can be a string (path to \"texlab.jar\") or the symbol search-from-exec-path. See the docstring of `lsp-latex-get-texlab-jar-file'."
   :group 'lsp-latex
-  :type '(choice string symbol))
+  :type '(choice string (const search-from-exec-path)))
 
 (defcustom lsp-latex-texlab-jar-argument-list '()
   "List of arguments passed to `lsp-latex-texlab-jar-file'. "

--- a/lsp-latex.el
+++ b/lsp-latex.el
@@ -28,6 +28,7 @@
 
 ;;; Code:
 (require 'lsp-mode)
+(require 'seq)
 
 (defgroup lsp-latex nil
   "Language Server Protocol client for LaTeX."


### PR DESCRIPTION
When `lsp-latex-get-texlab-jar-file` is the symbol `search-from-exec-path`, then `texlab.jar` will be searched from `exec-path`.