### PR TITLE
Use `locate-file` in `lsp-latex-get-texlab-jar-file`

### DIFF
--- a/lsp-latex.el
+++ b/lsp-latex.el
@@ -71,17 +71,10 @@ If `lsp-latex-texlab-jar-file' is the symbol search-from-exec-path, then search 
    ((stringp lsp-latex-texlab-jar-file)
     lsp-latex-texlab-jar-file)
    ((eq lsp-latex-texlab-jar-file 'search-from-exec-path)
-    (let* ((jar-filename "texlab.jar")
-           (jar-dir (or (seq-find (lambda (dir)
-                                    (let ((path (format "%s/%s"
-                                                        dir jar-filename)))
-                                      (when (file-exists-p path)
-                                        path)))
-                                  exec-path)
-                        (error (format "\"%s\" not found in `exec-path'"
-                                       jar-filename)))))
-      (format "%s/%s"
-              jar-dir jar-filename)))
+    (let ((jar-filename "texlab.jar"))
+      (or (locate-file jar-filename exec-path)
+          (error (format "\"%s\" not found in `exec-path'"
+                         jar-filename)))))
    (t (error "invalid value of `lsp-latex-texlab-jar-file'"))))
 
 (defun lsp-latex-new-connection ()

--- a/lsp-latex.el
+++ b/lsp-latex.el
@@ -28,7 +28,6 @@
 
 ;;; Code:
 (require 'lsp-mode)
-(require 'seq)
 
 (defgroup lsp-latex nil
   "Language Server Protocol client for LaTeX."


### PR DESCRIPTION
Use `locate-file` in `lsp-latex-get-texlab-jar-file`, following an advice from @conao3.