### PR TITLE
Handle AUCTeX's new mode naming convention

### DIFF
--- a/lsp-latex.el
+++ b/lsp-latex.el
@@ -964,8 +964,10 @@ PARAMS progress report notification data."
                   (lsp-stdio-connection
                    #'lsp-latex-new-connection)
                   :major-modes '(tex-mode
+                                 TeX-mode ;; AUCTeX 14+ has renamed tex-mode to TeX-mode
                                  yatex-mode
                                  latex-mode
+                                 LaTeX-mode  ;; AUCTeX 14+ has renamed latex-mode to LaTeX-mode
                                  bibtex-mode)
                   :server-id 'texlab2
                   :priority 2


### PR DESCRIPTION
Recently, AUCTeX renamed several of its major modes to avoid shadowing emacs built-in modes. This is documented here: https://git.savannah.gnu.org/cgit/auctex.git/tree/doc/changes.texi

As a result, if one has the newer version of AUCTeX (the version currently available from ELPA) then when they activate LaTeX-mode, lsp will be unavailable.

This is a simple fix to add support for the new TeX-mode and LaTeX-mode.